### PR TITLE
Fixed typographical error, changed architechture to architecture in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It's pretty huge project, and there is not much IDEs made purely on web technolo
 
 @NickHolder did amazing job on outline panel(types, scope of functions and variables, sorting).
 
-###Architechture controversy
+###Architecture controversy
 At start @as3boyan and @misterpah worked on one branch(master).
 @as3boyan and @misterpah argued a lot on plugin system implementation(which was requirement from Haxe Foundation).
 @as3boyan and @misterpah implemented their own plugin systems.


### PR DESCRIPTION
@HaxeIDE, I've corrected a typographical error in the documentation of the [HIDE](https://github.com/HaxeIDE/HIDE) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.