### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,4 +1,4 @@
-###How to contribute:
+### How to contribute:
 
 1. Make sure you have a [GitHub Account](https://github.com/signup/free)
 2. Fork [HIDE](https://github.com/misterpah/hide)
@@ -9,7 +9,7 @@
 
 Contributions are welcome.
 
-###Getting help
+### Getting help
 
 Community discussion, questions, and informal bug reporting is done on the
 [HIDE Google group](https://groups.google.com/group/haxeide).
@@ -19,9 +19,9 @@ Community discussion, questions, and informal bug reporting is done on the
 The preferred way to report bugs is to use the
 [GitHub issue tracker](https://github.com/misterpah/hide/issues).
 
-###Developer's Guide
+### Developer's Guide
 
-####How HIDE works
+#### How HIDE works
 
 A few words on inner structure of HIDE.
 
@@ -37,13 +37,13 @@ to html page. Which will cause script loading and execution.
 
 NOTE: HIDE tracks changes in plugins and recompiles plugin if it's source was changed.
 
-####Plugin Structure:
+#### Plugin Structure:
 
 Required files:
 1. plugin.hxml
 2. bin/Main.js
 
-####How to develop a plugin
+#### How to develop a plugin
 
 Create a copy of "plugins/boyan/samples/helloworld" folder.
 And rename it to plugin name, for example "plugins/john/samples/test".

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ HIDE - cross platform IDE for Haxe programming language
 
 Thanks to a group of [crowd funders at IndieGoGo](http://www.indiegogo.com/projects/cactus-ide/), HIDE is open source, licensed under the terms of the MIT License.
 
-###History
+### History
 Project was actively developed for almost a year by @as3boyan. (Summer 2013 - Summer 2014).
 It's pretty huge project, and there is not much IDEs made purely on web technologies.
 @misterpah gave this project great starting boost with making starting menu and choosing Bootstrap framework as main framework for GUI. After that it was maintained mostly by @as3boyan. @misterpah decided to develop it's own IDE for Haxe, named Haxe Studio.
 
 @NickHolder did amazing job on outline panel(types, scope of functions and variables, sorting).
 
-###Architecture controversy
+### Architecture controversy
 At start @as3boyan and @misterpah worked on one branch(master).
 @as3boyan and @misterpah argued a lot on plugin system implementation(which was requirement from Haxe Foundation).
 @as3boyan and @misterpah implemented their own plugin systems.
@@ -22,7 +22,7 @@ Anyway, they both worked on different branches.
 >Most IDEs integrate basic functionality to the core, for performance and stability reasons. And having lots of plugins, makes it harder to manage dependencies.
 
 
-###Project funding
+### Project funding
 $2,740USD(including 7% fees) were equally split between two developers: @as3boyan and @misterpah.
 
 Google Plus:
@@ -33,7 +33,7 @@ Google Group:
 
 There, you can discuss anything related to HIDE; including features requests, bugs, or just give feedback about HIDE.
 
-###How to run:
+### How to run:
 
 ``` haxe
 haxelib install HIDE
@@ -92,7 +92,7 @@ npm install
 ##### Contributing
 I am always thrilled to receive pull requests, and I do my best to process them as fast as possible. Not sure if that typo is worth a pull request? Do it! I will appreciate it.
 
-###License:
+### License:
 HIDE is licensed under the terms of the MIT License.
 CodeMirror is licensed under the terms of the MIT License.
 JQuery is licensed under the terms of the MIT License.

--- a/bin/node_modules/mv/node_modules/ncp/LICENSE.md
+++ b/bin/node_modules/mv/node_modules/ncp/LICENSE.md
@@ -1,6 +1,6 @@
 # MIT License
 
-###Copyright (C) 2011 by Charlie McConnell
+### Copyright (C) 2011 by Charlie McConnell
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/bin/node_modules/walkdir/readme.md
+++ b/bin/node_modules/walkdir/readme.md
@@ -82,59 +82,59 @@ walkdir.sync(path, [options], [callback]);
 
 non error type events are emitted with (path,stat). stat is an instanceof fs.Stats
 
-###path
+### path
 fired for everything
 
-###file
+### file
 fired only for regular files
 
-###directory
+### directory
 fired only for directories
 
-###link
+### link
 fired when a symbolic link is found
 
-###end
+### end
 fired when the entire tree has been read and emitted.
 
-###socket
+### socket
 fired when a socket descriptor is found
 
-###fifo
+### fifo
 fired when a fifo is found
 
-###characterdevice
+### characterdevice
 fired when a character device is found
 
-###blockdevice
+### blockdevice
 fired when a block device is found
 
-###targetdirectory
+### targetdirectory
 fired for the stat of the path you provided as the first argument. is is only fired if it is a directory.
 
-###empty
+### empty
 fired for empty directory
 
 ## error events
 error type events are emitted with (path,error). error being the error object returned from an fs call or other opperation.
 
-###error
+### error
 if the target path cannot be read an error event is emitted. this is the only failure case.
 
-###fail
+### fail
 when stat or read fails on a path somewhere in the walk and it is not your target path you get a fail event instead of error.
 This is handy if you want to find places you dont have access too.
 
 ## notes
 the async emitter returned supports 3 methods
 
-###end
+### end
   stop a walk in progress
 
-###pause
+### pause
   pause the walk. no more events will be emitted until resume
 
-###resume
+### resume
   resume the walk
 
 ### cancel a walk in progress

--- a/suggestions.md
+++ b/suggestions.md
@@ -136,7 +136,7 @@ get list of haxelibs(using haxelib list) and provide autocompletion for "-lib |"
 * Capture page button
 * Check if new version of HIDE is available
 
-###Important
+### Important
 * When user create/remove folder - update file tree
 * OpenFL projects should be created with -debug flag
 * Changing run command for OpenFL projects doesn't affect build command


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
